### PR TITLE
Make pack name configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# flyte-serf 
+# flyte-serf
 
 ![Build Status](https://travis-ci.org/HotelsDotCom/flyte-serf.svg?branch=master)
 [![Docker Stars](https://img.shields.io/docker/stars/hotelsdotcom/flyte-serf.svg)](https://hub.docker.com/r/hotelsdotcom/flyte-serf)
@@ -17,14 +17,15 @@ It provides two triggers `UserEvent`, `MemberEvent` and one command `SendEvent`.
 | SERF_JOIN_HOSTS   |                              | Address of another agent to join upon starting up. This can be comma delimited to specify multiple agents to join. |
 | SERF_KEYRING_FILE |                              | Specifies a file to load keyring data from. |
 | FLYTE_API         |                              | The FLYTE API endpoint to use. |
+| PACK_NAME         | Serf                         | Specifies pack name to register with. |
 
 ## Events
 
 ### UserEvent
-This event is invoked when Serf agent receives user event. Event output is a map of strings 
+This event is invoked when Serf agent receives user event. Event output is a map of strings
 ```
 {
-    "name": "...user event name...", 
+    "name": "...user event name...",
     "payload": "...user event payload..."
 }
 ```
@@ -44,8 +45,8 @@ Event output is a map of strings
 This event is emitted on the successful invocation of the `SendEvent` command. It's payload is:
 ```
 {
-    "name": "...user event name...", 
-    "payload": "...user event payload...", 
+    "name": "...user event name...",
+    "payload": "...user event payload...",
     "coalesce": "...coalesce flag..."
 }
 ```
@@ -56,11 +57,11 @@ This event is emitted on the unsuccessful invocation of the `SendEvent` command.
 ## Commands
 
 ### SendEvent
-This command sends user event to a serf cluster. Command's input is 
+This command sends user event to a serf cluster. Command's input is
 ```
 {
-    "name": "...user event name...", 
-    "payload": "...user event payload...", 
+    "name": "...user event name...",
+    "payload": "...user event payload...",
     "coalesce": "...coalesce flag..."
 }
 ```
@@ -78,7 +79,7 @@ To build and run from the command line:
 * Clone this repo
 * Run `go build`
 * FLYTE_API="FLYTE_API_URL" ./flyte-serf
-    
+
 ### Docker
 
     docker build -t flyte-serf:latest .

--- a/main.go
+++ b/main.go
@@ -69,11 +69,11 @@ func main() {
 }
 
 func getPackName() string {
-	var pack = defaultPackName
+	var pack = os.Getenv("PACK_NAME")
 
-	if os.Getenv("PACK_NAME") != "" {
-		pack = os.Getenv("PACK_NAME")
-		log.Printf("[INFO] PACK_NAME environment variable is set to %s.", pack)
+	if pack == "" {
+		log.Printf("[INFO] PACK_NAME environment variable is not set use %s as pack name.", defaultPackName)
+		return defaultPackName
 	}
 
 	log.Printf("[INFO] Use %s as pack name.", pack)

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 	"time"
 )
 
-const packName = "Serf"
+const defaultPackName = "Serf"
 
 func main() {
 	handler := &event.UserEventHandler{}
@@ -43,7 +43,7 @@ func main() {
 	defer a.Shutdown()
 
 	packDef := flyte.PackDef{
-		Name:    packName,
+		Name:    getPackName(),
 		HelpURL: parseURL("https://github.com/HotelsDotCom/flyte-serf/blob/master/README.md"),
 		Commands: []flyte.Command{
 			command.SendEventCommand(a),
@@ -66,6 +66,17 @@ func main() {
 	case <-a.ShutdownCh():
 	}
 	a.Leave()
+}
+
+func getPackName() string {
+	var pack = os.Getenv("PACK_NAME")
+	if pack != "" {
+		log.Printf("[INFO] PACK_NAME environment variable is set to %s.", pack)
+	} else {
+		pack = defaultPackName
+	}
+	log.Printf("[INFO] Use %s as pack name.", pack)
+	return pack
 }
 
 func getHost() *url.URL {

--- a/main.go
+++ b/main.go
@@ -69,12 +69,13 @@ func main() {
 }
 
 func getPackName() string {
-	var pack = os.Getenv("PACK_NAME")
-	if pack != "" {
+	var pack = defaultPackName
+
+	if os.Getenv("PACK_NAME") != "" {
+		pack = os.Getenv("PACK_NAME")
 		log.Printf("[INFO] PACK_NAME environment variable is set to %s.", pack)
-	} else {
-		pack = defaultPackName
 	}
+
 	log.Printf("[INFO] Use %s as pack name.", pack)
 	return pack
 }


### PR DESCRIPTION
It would be a useful feature to be able to configure the name of the pack as an environment variable. One can run multiple instances of flyte-serf pack e.g. due to testing purposes. Please have a look at this PR and review it.